### PR TITLE
fix module name + please push a tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/smartystreets/mafsa
+module github.com/Shugyousha/mafsa
 
 go 1.12


### PR DESCRIPTION
This is somewhat of a follow up on https://github.com/dvirsky/levenshtein/pull/6 in that it helps switch to this fork from that package.  

I didn't realize this change was needed until the above PR got merged & I attempted to remove my `go mod edit -replace` call. For some reason the behavior of said command is different to the more usual way of replacing a dependency:
```
go get -u -v github.com/dvirsky/levenshtein
go: github.com/dvirsky/levenshtein upgrade => v0.0.0-20200624034316-59b26b61c3c8
go: finding module for package github.com/Shugyousha/mafsa
go: found github.com/Shugyousha/mafsa in github.com/Shugyousha/mafsa v0.1.0
go: github.com/dvirsky/levenshtein imports
	github.com/Shugyousha/mafsa: github.com/Shugyousha/mafsa@v0.1.0: parsing go.mod:
	module declares its path as: github.com/smartystreets/mafsa
	        but was required as: github.com/Shugyousha/mafsa
```